### PR TITLE
Implement Marshalling for result structs containing Group elements

### DIFF
--- a/pkg/party/id.go
+++ b/pkg/party/id.go
@@ -1,9 +1,11 @@
 package party
 
 import (
+	"errors"
 	"io"
 
 	"github.com/cronokirby/safenum"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/taurusgroup/multi-party-sig/pkg/math/curve"
 )
 
@@ -38,4 +40,62 @@ func (id ID) WriteTo(w io.Writer) (int64, error) {
 // Domain implements hash.WriterToWithDomain, and separates this type within hash.Hash.
 func (ID) Domain() string {
 	return "ID"
+}
+
+// PointMap is a map from party ID's to points, to be easy to marshal.
+//
+// When unmarshalling, EmptyPointMap must be called first, to provide a group
+// to use to unmarshal the points.
+type PointMap struct {
+	group  curve.Curve
+	Points map[ID]curve.Point
+}
+
+// NewPointMap creates a PointMap from a map of points.
+func NewPointMap(points map[ID]curve.Point) *PointMap {
+	var group curve.Curve
+	for _, v := range points {
+		group = v.Curve()
+		break
+	}
+	return &PointMap{group: group, Points: points}
+}
+
+// EmptyPointMap creates an empty PointMap with a fixed group, ready to be unmarshalled.
+//
+// This needs to be used before unmarshalling, so that we have a group to unmarshal
+// the points inside of the map.
+func EmptyPointMap(group curve.Curve) *PointMap {
+	return &PointMap{group: group}
+}
+
+func (m *PointMap) MarshalBinary() ([]byte, error) {
+	pointBytes := make(map[ID]cbor.RawMessage, len(m.Points))
+	var err error
+	for k, v := range m.Points {
+		pointBytes[k], err = cbor.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cbor.Marshal(pointBytes)
+}
+
+func (m *PointMap) UnmarshalBinary(data []byte) error {
+	if m.group == nil {
+		return errors.New("PointMap.UnmarshalBinary called without setting a group")
+	}
+	pointBytes := make(map[ID]cbor.RawMessage)
+	if err := cbor.Unmarshal(data, &pointBytes); err != nil {
+		return err
+	}
+	m.Points = make(map[ID]curve.Point, len(pointBytes))
+	for k, v := range pointBytes {
+		point := m.group.NewPoint()
+		if err := cbor.Unmarshal(v, point); err != nil {
+			return err
+		}
+		m.Points[k] = point
+	}
+	return nil
 }

--- a/protocols/cmp/keygen/config.go
+++ b/protocols/cmp/keygen/config.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/cronokirby/safenum"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/taurusgroup/multi-party-sig/internal/bip32"
 	"github.com/taurusgroup/multi-party-sig/internal/params"
 	"github.com/taurusgroup/multi-party-sig/pkg/math/curve"
@@ -28,12 +29,69 @@ type Public struct {
 	T *safenum.Nat
 }
 
+// PublicMap holds a map of the Public results associated with each party.
+//
+// This struct exists mainly for easier marshalling.
+type PublicMap struct {
+	group curve.Curve
+	Data  map[party.ID]*Public
+}
+
+// NewPublicMap creates a PublicMap given the underlying map of data.
+func NewPublicMap(data map[party.ID]*Public) *PublicMap {
+	var group curve.Curve
+	for _, v := range data {
+		group = v.ECDSA.Curve()
+		break
+	}
+	return &PublicMap{group: group, Data: data}
+}
+
+// EmptyPublicMap creates a PublicMap ready to be unmarshalled, using a specific group.
+//
+// This function needs to be called for unmarshalling to work correctly.
+func EmptyPublicMap(group curve.Curve) *PublicMap {
+	return &PublicMap{group: group}
+}
+
+func (m *PublicMap) MarshalBinary() ([]byte, error) {
+	byteMap := make(map[party.ID]cbor.RawMessage, len(m.Data))
+	var err error
+	for k, v := range m.Data {
+		byteMap[k], err = cbor.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cbor.Marshal(byteMap)
+}
+
+func (m *PublicMap) UnmarshalBinary(data []byte) error {
+	if m.group == nil {
+		return errors.New("PublicMap.UnmarshalBinary called without setting a group")
+	}
+	byteMap := make(map[party.ID]cbor.RawMessage)
+	if err := cbor.Unmarshal(data, &byteMap); err != nil {
+		return err
+	}
+	m.Data = make(map[party.ID]*Public, len(byteMap))
+	for k, v := range byteMap {
+		public := Public{ECDSA: m.group.NewPoint()}
+		if err := cbor.Unmarshal(v, &public); err != nil {
+			return err
+		}
+		m.Data[k] = &public
+	}
+	return nil
+}
+
 // Config represents the SSID after having performed a keygen/refresh operation.
 // It represents ssid = (sid, (N₁, s₁, t₁), …, (Nₙ, sₙ, tₙ))
 // where sid = (𝔾, t, n, P₁, …, Pₙ).
+//
+// To unmarshal this struct, EmptyConfig should be called first with a specific group,
+// before using cbor.Unmarshal with that struct.
 type Config struct {
-	Group curve.Curve
-
 	ID party.ID
 
 	// Threshold is the integer t which defines the maximum number of corruptions tolerated for this config.
@@ -46,8 +104,8 @@ type Config struct {
 	// P, Q is the primes for N = P*Q used by Paillier and Pedersen
 	P, Q *safenum.Nat
 
-	// Public maps party.ID to party. It contains all public information associated to a party.
-	Public map[party.ID]*Public
+	// Public maps party.ID to public. It contains all public information associated to a party.
+	Public *PublicMap
 
 	// RID is a 32 byte random identifier generated for this config
 	RID RID
@@ -55,15 +113,28 @@ type Config struct {
 	ChainKey []byte
 }
 
+// EmptyConfig creates an empty Config with a fixed group, ready for unmarshalling.
+//
+// This needs to be used for unmarshalling, otherwise the points on the curve can't
+// be decoded.
+func EmptyConfig(group curve.Curve) *Config {
+	return &Config{Public: EmptyPublicMap(group), ECDSA: group.NewScalar()}
+}
+
+// Group returns the Elliptic Curve Group associated with this config.
+func (c *Config) Group() curve.Curve {
+	return c.ECDSA.Curve()
+}
+
 // PublicPoint returns the group's public ECC point.
-func (c Config) PublicPoint() curve.Point {
-	sum := c.Group.NewPoint()
-	partyIDs := make([]party.ID, 0, len(c.Public))
-	for j := range c.Public {
+func (c *Config) PublicPoint() curve.Point {
+	sum := c.Group().NewPoint()
+	partyIDs := make([]party.ID, 0, len(c.Public.Data))
+	for j := range c.Public.Data {
 		partyIDs = append(partyIDs, j)
 	}
-	l := polynomial.Lagrange(c.Group, partyIDs)
-	for j, partyJ := range c.Public {
+	l := polynomial.Lagrange(c.Group(), partyIDs)
+	for j, partyJ := range c.Public.Data {
 		sum = sum.Add(l[j].Act(partyJ.ECDSA))
 	}
 	return sum
@@ -73,10 +144,10 @@ func (c Config) PublicPoint() curve.Point {
 // - 0 ⩽ threshold ⩽ n-1
 // - all public data is present and valid
 // - the secret corresponds to the data from an included party.
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
 	// verify number of parties w.r.t. threshold
 	// want 0 ⩽ threshold ⩽ n-1
-	if !validThreshold(int(c.Threshold), len(c.Public)) {
+	if !validThreshold(int(c.Threshold), len(c.Public.Data)) {
 		return fmt.Errorf("config: threshold %d is invalid", c.Threshold)
 	}
 
@@ -97,7 +168,7 @@ func (c Config) Validate() error {
 		return fmt.Errorf("config: prime q: %w", err)
 	}
 
-	for j, publicJ := range c.Public {
+	for j, publicJ := range c.Public.Data {
 		// validate public
 		if err := publicJ.validate(); err != nil {
 			return fmt.Errorf("config: party %s: %w", j, err)
@@ -105,7 +176,7 @@ func (c Config) Validate() error {
 	}
 
 	// verify our ID is present
-	public := c.Public[c.ID]
+	public := c.Public.Data[c.ID]
 	if public == nil {
 		return errors.New("config: no public data for secret")
 	}
@@ -127,9 +198,9 @@ func (c Config) Validate() error {
 }
 
 // PartyIDs returns a sorted slice of party IDs.
-func (c Config) PartyIDs() party.IDSlice {
-	ids := make([]party.ID, 0, len(c.Public))
-	for j := range c.Public {
+func (c *Config) PartyIDs() party.IDSlice {
+	ids := make([]party.ID, 0, len(c.Public.Data))
+	for j := range c.Public.Data {
 		ids = append(ids, j)
 	}
 	return party.NewIDSlice(ids)
@@ -196,7 +267,7 @@ func (c *Config) WriteTo(w io.Writer) (total int64, err error) {
 	// write all party data
 	for _, j := range partyIDs {
 		// write Xⱼ
-		n, err = c.Public[j].WriteTo(w)
+		n, err = c.Public.Data[j].WriteTo(w)
 		total += n
 		if err != nil {
 			return
@@ -207,7 +278,7 @@ func (c *Config) WriteTo(w io.Writer) (total int64, err error) {
 }
 
 // Domain implements hash.WriterToWithDomain.
-func (c Config) Domain() string {
+func (c *Config) Domain() string {
 	return "CMP Config"
 }
 
@@ -265,7 +336,7 @@ func (c *Config) CanSign(signers party.IDSlice) bool {
 	// check that the signers are a subset of the original parties,
 	// that it includes self, and that the size is > t.
 	for _, j := range signers {
-		if _, ok := c.Public[j]; !ok {
+		if _, ok := c.Public.Data[j]; !ok {
 			return false
 		}
 	}
@@ -309,8 +380,8 @@ func (c *Config) DeriveChild(i uint32) (*Config, error) {
 
 	scalarG := scalar.ActOnBase()
 
-	publics := make(map[party.ID]*Public, len(c.Public))
-	for k, v := range c.Public {
+	publics := make(map[party.ID]*Public, len(c.Public.Data))
+	for k, v := range c.Public.Data {
 		publics[k] = &Public{
 			ECDSA: v.ECDSA.Add(scalarG),
 			N:     v.N,
@@ -320,13 +391,12 @@ func (c *Config) DeriveChild(i uint32) (*Config, error) {
 	}
 
 	return &Config{
-		Group:     c.Group,
 		Threshold: c.Threshold,
-		Public:    publics,
+		Public:    NewPublicMap(publics),
 		RID:       c.RID,
 		ChainKey:  newChainKey,
 		ID:        c.ID,
-		ECDSA:     c.Group.NewScalar().Set(c.ECDSA).Add(scalar),
+		ECDSA:     c.Group().NewScalar().Set(c.ECDSA).Add(scalar),
 		P:         c.P,
 		Q:         c.Q,
 	}, nil

--- a/protocols/cmp/keygen/config_fake.go
+++ b/protocols/cmp/keygen/config_fake.go
@@ -34,9 +34,8 @@ func FakeData(group curve.Curve, N, T int, source io.Reader, pl *pool.Pool) map[
 
 		ecdsaSecret := f.Evaluate(pid.Scalar(group))
 		configs[pid] = &Config{
-			Group:     group,
 			Threshold: uint32(T),
-			Public:    public,
+			Public:    NewPublicMap(public),
 			RID:       rid.Copy(),
 			ID:        pid,
 			ECDSA:     ecdsaSecret,

--- a/protocols/cmp/keygen/keygen.go
+++ b/protocols/cmp/keygen/keygen.go
@@ -68,7 +68,7 @@ func StartKeygen(pl *pool.Pool, group curve.Curve, partyIDs []party.ID, threshol
 
 func StartRefresh(pl *pool.Pool, c *Config) protocol.StartFunc {
 	return func() (round.Round, protocol.Info, error) {
-		group := c.Group
+		group := c.Group()
 
 		partyIDs := c.PartyIDs()
 		helper, err := round.NewHelper(
@@ -85,7 +85,7 @@ func StartRefresh(pl *pool.Pool, c *Config) protocol.StartFunc {
 
 		PreviousPublicSharesECDSA := make(map[party.ID]curve.Point, len(partyIDs))
 		for _, j := range partyIDs {
-			PreviousPublicSharesECDSA[j] = c.Public[j].ECDSA
+			PreviousPublicSharesECDSA[j] = c.Public.Data[j].ECDSA
 		}
 		PreviousSecretECDSA := group.NewScalar().Set(c.ECDSA)
 		PreviousPublicKey := c.PublicPoint()

--- a/protocols/cmp/keygen/round4.go
+++ b/protocols/cmp/keygen/round4.go
@@ -128,9 +128,8 @@ func (r *round4) Finalize(out chan<- *message.Message) (round.Round, error) {
 	}
 
 	UpdatedConfig := &Config{
-		Group:     r.Group(),
 		Threshold: uint32(r.Threshold),
-		Public:    PublicData,
+		Public:    NewPublicMap(PublicData),
 		RID:       r.RID.Copy(),
 		ChainKey:  r.ChainKey,
 		ID:        r.SelfID(),

--- a/protocols/cmp/keygen/round_output.go
+++ b/protocols/cmp/keygen/round_output.go
@@ -34,7 +34,7 @@ func (r *output) VerifyMessage(from party.ID, _ party.ID, content message.Conten
 	}
 
 	if !body.SchnorrResponse.Verify(r.HashForID(from),
-		r.UpdatedConfig.Public[from].ECDSA,
+		r.UpdatedConfig.Public.Data[from].ECDSA,
 		r.SchnorrCommitments[from]) {
 		return ErrRoundOutputZKSch
 	}

--- a/protocols/cmp/sign/sign.go
+++ b/protocols/cmp/sign/sign.go
@@ -33,7 +33,7 @@ var (
 
 func StartSign(pl *pool.Pool, config *keygen.Config, signers []party.ID, message []byte) protocol.StartFunc {
 	return func() (round.Round, protocol.Info, error) {
-		group := config.Group
+		group := config.Group()
 
 		// this could be used to indicate a pre-signature later on
 		if len(message) == 0 {
@@ -81,7 +81,7 @@ func StartSign(pl *pool.Pool, config *keygen.Config, signers []party.ID, message
 		SecretECDSA := group.NewScalar().Set(lagrange[config.ID]).Mul(config.ECDSA)
 		SecretPaillier := config.Paillier()
 		for _, j := range signerIDs {
-			public := config.Public[j]
+			public := config.Public.Data[j]
 			// scale public key share
 			ECDSA[j] = lagrange[j].Act(public.ECDSA)
 			// create Paillier key, but set ours to the one derived from the private key

--- a/protocols/frost/keygen/keygen_test.go
+++ b/protocols/frost/keygen/keygen_test.go
@@ -98,9 +98,14 @@ func checkOutput(t *testing.T, rounds map[party.ID]round.Round, parties party.ID
 	}
 
 	for _, result := range results {
+		marshalled, err := cbor.Marshal(result)
+		require.NoError(t, err)
+		unmarshalledResult := EmptyResult(group)
+		err = cbor.Unmarshal(marshalled, unmarshalledResult)
+		require.NoError(t, err)
 		for _, party := range parties {
 			expected := shares[party].ActOnBase()
-			require.True(t, result.VerificationShares[party].Equal(expected))
+			require.True(t, unmarshalledResult.VerificationShares.Points[party].Equal(expected))
 		}
 	}
 }

--- a/protocols/frost/keygen/result.go
+++ b/protocols/frost/keygen/result.go
@@ -24,8 +24,6 @@ type Result struct {
 	ID party.ID
 	// Threshold is the number of accepted corruptions while still being able to sign.
 	Threshold int
-	// Group is the Elliptic Curve group used to produce this result
-	Group curve.Curve
 	// PrivateShare is the fraction of the secret key owned by this participant.
 	PrivateShare curve.Scalar
 	// PublicKey is the shared public key for this consortium of signers.
@@ -42,6 +40,11 @@ type Result struct {
 	VerificationShares map[party.ID]curve.Point
 }
 
+// Curve returns the Elliptic Curve Group associated with this result.
+func (r *Result) Curve() curve.Curve {
+	return r.PublicKey.Curve()
+}
+
 // Clone creates a deep clone of this struct, and all the values contained inside
 func (r *Result) Clone() *Result {
 	chainKeyCopy := make([]byte, len(r.ChainKey))
@@ -52,9 +55,8 @@ func (r *Result) Clone() *Result {
 	}
 	return &Result{
 		ID:                 r.ID,
-		Group:              r.Group,
 		Threshold:          r.Threshold,
-		PrivateShare:       r.Group.NewScalar().Set(r.PrivateShare),
+		PrivateShare:       r.Curve().NewScalar().Set(r.PrivateShare),
 		PublicKey:          r.PublicKey,
 		ChainKey:           chainKeyCopy,
 		VerificationShares: verificationSharesCopy,

--- a/protocols/frost/keygen/round3.go
+++ b/protocols/frost/keygen/round3.go
@@ -159,7 +159,7 @@ func (r *round3) Finalize(chan<- *message.Message) (round.Round, error) {
 		Threshold:          r.threshold,
 		PrivateShare:       s_i,
 		PublicKey:          Y,
-		VerificationShares: VerificationShares,
+		VerificationShares: party.NewPointMap(VerificationShares),
 	}}, nil
 }
 

--- a/protocols/frost/keygen/round3.go
+++ b/protocols/frost/keygen/round3.go
@@ -156,7 +156,6 @@ func (r *round3) Finalize(chan<- *message.Message) (round.Round, error) {
 
 	return &round.Output{Result: &Result{
 		ID:                 r.SelfID(),
-		Group:              r.Group(),
 		Threshold:          r.threshold,
 		PrivateShare:       s_i,
 		PublicKey:          Y,

--- a/protocols/frost/keygen/round3.go
+++ b/protocols/frost/keygen/round3.go
@@ -141,12 +141,16 @@ func (r *round3) Finalize(chan<- *message.Message) (round.Round, error) {
 				VerificationShares[i] = y_i.Negate()
 			}
 		}
+		secpVerificationShares := make(map[party.ID]*curve.Secp256k1Point)
+		for k, v := range VerificationShares {
+			secpVerificationShares[k] = v.(*curve.Secp256k1Point)
+		}
 		return &round.Output{Result: &TaprootResult{
 			ID:                 r.SelfID(),
 			Threshold:          r.threshold,
-			PrivateShare:       s_i,
+			PrivateShare:       s_i.(*curve.Secp256k1Scalar),
 			PublicKey:          YSecp.XBytes()[:],
-			VerificationShares: VerificationShares,
+			VerificationShares: secpVerificationShares,
 		}}, nil
 	}
 

--- a/protocols/frost/sign/sign.go
+++ b/protocols/frost/sign/sign.go
@@ -93,13 +93,17 @@ func StartSign(result *keygen.Result, signers []party.ID, messageHash []byte) pr
 // See: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 func StartSignTaproot(result *keygen.TaprootResult, signers []party.ID, messageHash []byte) protocol.StartFunc {
 	publicKey, err := curve.Secp256k1{}.LiftX(result.PublicKey)
+	genericVerificationShares := make(map[party.ID]curve.Point)
+	for k, v := range result.VerificationShares {
+		genericVerificationShares[k] = v
+	}
 	normalResult := &keygen.Result{
 		Group:              curve.Secp256k1{},
 		ID:                 result.ID,
 		Threshold:          result.Threshold,
 		PrivateShare:       result.PrivateShare,
 		PublicKey:          publicKey,
-		VerificationShares: result.VerificationShares,
+		VerificationShares: genericVerificationShares,
 	}
 	return startSignCommon(true, err, normalResult, signers, messageHash)
 }

--- a/protocols/frost/sign/sign.go
+++ b/protocols/frost/sign/sign.go
@@ -56,7 +56,7 @@ func startSignCommon(taproot bool, err error, result *keygen.Result, signers []p
 			taproot: taproot,
 			M:       messageHash,
 			Y:       result.PublicKey,
-			YShares: result.VerificationShares,
+			YShares: result.VerificationShares.Points,
 			s_i:     result.PrivateShare,
 		}, helper, nil
 	}
@@ -102,7 +102,7 @@ func StartSignTaproot(result *keygen.TaprootResult, signers []party.ID, messageH
 		Threshold:          result.Threshold,
 		PrivateShare:       result.PrivateShare,
 		PublicKey:          publicKey,
-		VerificationShares: genericVerificationShares,
+		VerificationShares: party.NewPointMap(genericVerificationShares),
 	}
 	return startSignCommon(true, err, normalResult, signers, messageHash)
 }

--- a/protocols/frost/sign/sign.go
+++ b/protocols/frost/sign/sign.go
@@ -21,7 +21,7 @@ const (
 
 func startSignCommon(taproot bool, err error, result *keygen.Result, signers []party.ID, messageHash []byte) protocol.StartFunc {
 	return func() (round.Round, protocol.Info, error) {
-		group := result.Group
+		group := result.Curve()
 		// This is a bit of a hack, so that the Taproot can tell this function that the public key
 		// is invalid.
 		if err != nil {
@@ -98,7 +98,6 @@ func StartSignTaproot(result *keygen.TaprootResult, signers []party.ID, messageH
 		genericVerificationShares[k] = v
 	}
 	normalResult := &keygen.Result{
-		Group:              curve.Secp256k1{},
 		ID:                 result.ID,
 		Threshold:          result.Threshold,
 		PrivateShare:       result.PrivateShare,

--- a/protocols/frost/sign/sign_test.go
+++ b/protocols/frost/sign/sign_test.go
@@ -106,7 +106,7 @@ func TestSign(t *testing.T) {
 			Threshold:          threshold,
 			PublicKey:          publicKey,
 			PrivateShare:       privateShares[id],
-			VerificationShares: verificationShares,
+			VerificationShares: party.NewPointMap(verificationShares),
 			ChainKey:           chainKey,
 		}
 		result, _ = result.DeriveChild(1)

--- a/protocols/frost/sign/sign_test.go
+++ b/protocols/frost/sign/sign_test.go
@@ -156,14 +156,14 @@ func TestSignTaproot(t *testing.T) {
 	chainKey := make([]byte, params.SecBytes)
 	_, _ = rand.Read(chainKey)
 
-	privateShares := make(map[party.ID]curve.Scalar, N)
+	privateShares := make(map[party.ID]*curve.Secp256k1Scalar, N)
 	for _, id := range partyIDs {
-		privateShares[id] = f.Evaluate(id.Scalar(group))
+		privateShares[id] = f.Evaluate(id.Scalar(group)).(*curve.Secp256k1Scalar)
 	}
 
-	verificationShares := make(map[party.ID]curve.Point, N)
+	verificationShares := make(map[party.ID]*curve.Secp256k1Point, N)
 	for _, id := range partyIDs {
-		verificationShares[id] = privateShares[id].ActOnBase()
+		verificationShares[id] = privateShares[id].ActOnBase().(*curve.Secp256k1Point)
 	}
 
 	var newPublicKey []byte

--- a/protocols/frost/sign/sign_test.go
+++ b/protocols/frost/sign/sign_test.go
@@ -103,7 +103,6 @@ func TestSign(t *testing.T) {
 	for _, id := range partyIDs {
 		result := &keygen.Result{
 			ID:                 id,
-			Group:              group,
 			Threshold:          threshold,
 			PublicKey:          publicKey,
 			PrivateShare:       privateShares[id],


### PR DESCRIPTION
Fixes #57.

This changes these structs to require calling an `EmptyResult(group)` method, to fix the group used for unmarshalling.