### PR TITLE
protocol: implement correct broadcast for all protocols

### DIFF
--- a/internal/test/network.go
+++ b/internal/test/network.go
@@ -23,7 +23,7 @@ func NewNetwork(parties party.IDSlice) *Network {
 	close(closed)
 	c := &Network{
 		parties:          parties,
-		listenChannels:   make(map[party.ID]chan *protocol.Message, len(parties)),
+		listenChannels:   make(map[party.ID]chan *protocol.Message, 2*len(parties)),
 		closedListenChan: closed,
 	}
 	return c

--- a/pkg/protocol/handler.go
+++ b/pkg/protocol/handler.go
@@ -128,6 +128,11 @@ func (h *Handler) Update(msg *Message) {
 		return
 	}
 
+	h.store(msg)
+	if h.currentRound.Number() != msg.RoundNumber {
+		return
+	}
+
 	if msg.Broadcast {
 		if err := h.verifyBroadcastMessage(msg); err != nil {
 			h.abort(err, msg.From)
@@ -140,7 +145,6 @@ func (h *Handler) Update(msg *Message) {
 		}
 	}
 
-	h.store(msg)
 	h.finalize()
 }
 

--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -224,6 +224,9 @@ func (r *Response) Verify(n, w, y *big.Int) bool {
 }
 
 func (p *Proof) Verify(public Public, hash *hash.Hash, pl *pool.Pool) bool {
+	if p == nil {
+		return false
+	}
 	n := public.N.Big()
 	nMod := public.N
 	// check if n is odd and prime

--- a/pkg/zk/prm/prm.go
+++ b/pkg/zk/prm/prm.go
@@ -78,6 +78,9 @@ func NewProof(private Private, hash *hash.Hash, public Public, pl *pool.Pool) *P
 }
 
 func (p *Proof) Verify(public Public, hash *hash.Hash, pl *pool.Pool) bool {
+	if p == nil {
+		return false
+	}
 	if err := pedersen.ValidateParameters(public.N, public.S, public.T); err != nil {
 		return false
 	}

--- a/protocols/cmp/keygen/round1.go
+++ b/protocols/cmp/keygen/round1.go
@@ -96,13 +96,13 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	}
 
 	// should be broadcast but we don't need that here
-	msg := &message2{Commitment: SelfCommitment}
+	msg := &broadcast2{Commitment: SelfCommitment}
 	err = r.BroadcastMessage(out, msg)
 	if err != nil {
 		return r, err
 	}
 
-	nextRound := &roundBroadcast2{&round2{
+	nextRound := &round2{
 		round1:         r,
 		VSSPolynomials: map[party.ID]*polynomial.Exponent{r.SelfID(): SelfVSSPolynomial},
 		Commitments:    map[party.ID]hash.Commitment{r.SelfID(): SelfCommitment},
@@ -119,7 +119,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		PedersenSecret: PedersenSecret,
 		SchnorrRand:    SchnorrRand,
 		Decommitment:   Decommitment,
-	}}
+	}
 	return nextRound, nil
 }
 

--- a/protocols/cmp/keygen/round2.go
+++ b/protocols/cmp/keygen/round2.go
@@ -58,19 +58,15 @@ type round2 struct {
 	Decommitment hash.Decommitment // uᵢ
 }
 
-type roundBroadcast2 struct {
-	*round2
-}
-
-type message2 struct {
+type broadcast2 struct {
 	// Commitment = Vᵢ = H(ρᵢ, Fᵢ(X), Aᵢ, Yᵢ, Nᵢ, sᵢ, tᵢ, uᵢ)
 	Commitment hash.Commitment
 }
 
 // StoreBroadcastMessage implements round.BroadcastRound.
 // - save commitment Vⱼ.
-func (r *roundBroadcast2) StoreBroadcastMessage(msg round.Message) error {
-	body, ok := msg.Content.(*message2)
+func (r *round2) StoreBroadcastMessage(msg round.Message) error {
+	body, ok := msg.Content.(*broadcast2)
 	if !ok || body == nil {
 		return round.ErrInvalidContent
 	}
@@ -92,7 +88,7 @@ func (round2) StoreMessage(round.Message) error { return nil }
 // - send all committed data.
 func (r *round2) Finalize(out chan<- *round.Message) (round.Session, error) {
 	// Send the message we created in Round1 to all
-	err := r.SendMessage(out, &message3{
+	err := r.BroadcastMessage(out, &broadcast3{
 		RID:                r.RIDs[r.SelfID()],
 		C:                  r.ChainKeys[r.SelfID()],
 		VSSPolynomial:      r.VSSPolynomials[r.SelfID()],
@@ -102,7 +98,7 @@ func (r *round2) Finalize(out chan<- *round.Message) (round.Session, error) {
 		S:                  r.S[r.SelfID()],
 		T:                  r.T[r.SelfID()],
 		Decommitment:       r.Decommitment,
-	}, "")
+	})
 	if err != nil {
 		return r, err
 	}
@@ -119,7 +115,7 @@ func (r *round2) PreviousRound() round.Round { return r.round1 }
 func (round2) MessageContent() round.Content { return nil }
 
 // BroadcastContent implements round.BroadcastRound.
-func (roundBroadcast2) BroadcastContent() round.Content { return &message2{} }
+func (round2) BroadcastContent() round.Content { return &broadcast2{} }
 
 // Number implements round.Round.
 func (round2) Number() round.Number { return 2 }

--- a/protocols/cmp/keygen/round5.go
+++ b/protocols/cmp/keygen/round5.go
@@ -15,22 +15,22 @@ type round5 struct {
 	UpdatedConfig *config.Config
 }
 
-type message5 struct {
+type broadcast5 struct {
 	// SchnorrResponse is the Schnorr proof of knowledge of the new secret share
 	SchnorrResponse *sch.Response
 }
 
-// VerifyMessage implements round.Round.
+// StoreBroadcastMessage implements round.BroadcastRound.
 //
 // - verify all Schnorr proof for the new ecdsa share.
-func (r *round5) VerifyMessage(msg round.Message) error {
+func (r *round5) StoreBroadcastMessage(msg round.Message) error {
 	from := msg.From
-	body, ok := msg.Content.(*message5)
+	body, ok := msg.Content.(*broadcast5)
 	if !ok || body == nil {
 		return round.ErrInvalidContent
 	}
 
-	if body.SchnorrResponse == nil {
+	if !body.SchnorrResponse.IsValid() {
 		return round.ErrNilFields
 	}
 
@@ -42,6 +42,9 @@ func (r *round5) VerifyMessage(msg round.Message) error {
 	return nil
 }
 
+// VerifyMessage implements round.Round.
+func (round5) VerifyMessage(round.Message) error { return nil }
+
 // StoreMessage implements round.Round.
 func (r *round5) StoreMessage(round.Message) error { return nil }
 
@@ -51,8 +54,11 @@ func (r *round5) Finalize(chan<- *round.Message) (round.Session, error) {
 }
 
 // MessageContent implements round.Round.
-func (r *round5) MessageContent() round.Content {
-	return &message5{
+func (r *round5) MessageContent() round.Content { return nil }
+
+// BroadcastContent implements round.BroadcastRound.
+func (r *round5) BroadcastContent() round.Content {
+	return &broadcast5{
 		SchnorrResponse: sch.EmptyResponse(r.Group()),
 	}
 }

--- a/protocols/cmp/presign/abort_test.go
+++ b/protocols/cmp/presign/abort_test.go
@@ -64,7 +64,7 @@ func TestRoundFail(t *testing.T) {
 				},
 				BeforeSend: func(rNext round.Session, to party.ID, content round.Content) {
 					r, okR := rNext.(*presign4)
-					c, okC := content.(*message4)
+					c, okC := content.(*broadcast4)
 					if okR || okC {
 						oneScalar := r.Group().NewScalar().SetNat(oneNat)
 						c.DeltaShare = r.Group().NewScalar().Set(c.DeltaShare).Sub(oneScalar)
@@ -92,7 +92,7 @@ func TestRoundFail(t *testing.T) {
 			TestRule{
 				BeforeFinalize: func(rPrevious round.Session) {
 					switch r := rPrevious.(type) {
-					case *presignBroadcast3:
+					case *presign3:
 						minusOne := r.Group().NewScalar().SetNat(oneNat).Negate()
 						r.SecretECDSA = minusOne.Add(r.SecretECDSA)
 					default:
@@ -112,7 +112,7 @@ func TestRoundFail(t *testing.T) {
 			"round 3 modify chi force abort",
 			TestRule{
 				AfterFinalize: func(rNext round.Session) {
-					if r, ok := rNext.(*presignBroadcast3); ok {
+					if r, ok := rNext.(*presign3); ok {
 						r.SecretECDSA = r.Group().NewScalar().SetNat(oneNat).Add(r.SecretECDSA)
 					}
 				},

--- a/protocols/cmp/presign/presign1.go
+++ b/protocols/cmp/presign/presign1.go
@@ -124,7 +124,7 @@ func (r *presign1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		}
 	}
 
-	return &presignBroadcast2{&presign2{
+	return &presign2{
 		presign1:       r,
 		K:              map[party.ID]*paillier.Ciphertext{r.SelfID(): K},
 		G:              map[party.ID]*paillier.Ciphertext{r.SelfID(): G},
@@ -137,7 +137,7 @@ func (r *presign1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		PresignatureID: map[party.ID]types.RID{r.SelfID(): presignatureID},
 		CommitmentID:   map[party.ID]hash.Commitment{},
 		DecommitmentID: decommitmentID,
-	}}, nil
+	}, nil
 }
 
 // MessageContent implements round.Round.

--- a/protocols/cmp/presign/presign2.go
+++ b/protocols/cmp/presign/presign2.go
@@ -52,10 +52,6 @@ type presign2 struct {
 	DecommitmentID hash.Decommitment
 }
 
-type presignBroadcast2 struct {
-	*presign2
-}
-
 type broadcast2 struct {
 	// K = Kᵢ
 	K *paillier.Ciphertext
@@ -74,7 +70,7 @@ type message2 struct {
 // StoreBroadcastMessage implements round.BroadcastRound.
 //
 // - store Kⱼ, Gⱼ, Zⱼ, CommitmentID.
-func (r *presignBroadcast2) StoreBroadcastMessage(msg round.Message) error {
+func (r *presign2) StoreBroadcastMessage(msg round.Message) error {
 	from := msg.From
 	body, ok := msg.Content.(*broadcast2)
 	if !ok || body == nil {
@@ -198,13 +194,13 @@ func (r *presign2) Finalize(out chan<- *round.Message) (round.Session, error) {
 		}
 	}
 
-	return &presignBroadcast3{&presign3{
+	return &presign3{
 		presign2:        r,
 		DeltaShareBeta:  DeltaShareBeta,
 		ChiShareBeta:    ChiShareBeta,
 		DeltaCiphertext: map[party.ID]map[party.ID]*paillier.Ciphertext{r.SelfID(): DeltaCiphertext},
 		ChiCiphertext:   map[party.ID]map[party.ID]*paillier.Ciphertext{r.SelfID(): ChiCiphertext},
-	}}, nil
+	}, nil
 }
 
 // MessageContent implements round.Round.
@@ -215,7 +211,7 @@ func (r *presign2) MessageContent() round.Content {
 }
 
 // BroadcastContent implements round.BroadcastRound.
-func (r *presignBroadcast2) BroadcastContent() round.Content {
+func (r *presign2) BroadcastContent() round.Content {
 	return &broadcast2{
 		Z: elgamal.Empty(r.Group()),
 	}

--- a/protocols/cmp/presign/presign3.go
+++ b/protocols/cmp/presign/presign3.go
@@ -30,10 +30,6 @@ type presign3 struct {
 	ChiCiphertext map[party.ID]map[party.ID]*paillier.Ciphertext
 }
 
-type presignBroadcast3 struct {
-	*presign3
-}
-
 type broadcast3 struct {
 	// DeltaCiphertext[k] = Dₖⱼ
 	DeltaCiphertext map[party.ID]*paillier.Ciphertext
@@ -48,9 +44,8 @@ type message3 struct {
 	ChiProof   *zkaffg.Proof
 }
 
-// StoreBroadcastMessage implements round.Round.
-//
-func (r *presignBroadcast3) StoreBroadcastMessage(msg round.Message) error {
+// StoreBroadcastMessage implements round.BroadcastRound.
+func (r *presign3) StoreBroadcastMessage(msg round.Message) error {
 	from := msg.From
 	body, ok := msg.Content.(*broadcast3)
 	if !ok || body == nil {
@@ -171,11 +166,11 @@ func (r *presign3) Finalize(out chan<- *round.Message) (round.Session, error) {
 
 	DeltaShareScalar := r.Group().NewScalar().SetNat(DeltaShare.Mod(r.Group().Order()))
 
-	msg := &message4{
+	msg := &broadcast4{
 		DeltaShare: DeltaShareScalar,
 		ElGamalChi: ElGamalChi,
 	}
-	if err = r.SendMessage(out, msg, ""); err != nil {
+	if err = r.BroadcastMessage(out, msg); err != nil {
 		return r, err
 	}
 
@@ -196,7 +191,7 @@ func (r *presign3) MessageContent() round.Content {
 }
 
 // BroadcastContent implements round.BroadcastRound.
-func (presignBroadcast3) BroadcastContent() round.Content { return &broadcast3{} }
+func (presign3) BroadcastContent() round.Content { return &broadcast3{} }
 
 // Number implements round.Round.
 func (presign3) Number() round.Number { return 3 }

--- a/protocols/cmp/presign/sign1.go
+++ b/protocols/cmp/presign/sign1.go
@@ -29,9 +29,9 @@ func (r *sign1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	// σᵢ = kᵢm+rχᵢ (mod q)
 	SigmaShare := r.PreSignature.SignatureShare(r.Message)
 
-	err := r.SendMessage(out, &messageSign2{
+	err := r.BroadcastMessage(out, &broadcastSign2{
 		Sigma: SigmaShare,
-	}, "")
+	})
 	if err != nil {
 		return r, err.(error)
 	}

--- a/protocols/cmp/sign/round1.go
+++ b/protocols/cmp/sign/round1.go
@@ -90,7 +90,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		}
 	}
 
-	return &roundBroadcast2{&round2{
+	return &round2{
 		round1:        r,
 		K:             map[party.ID]*paillier.Ciphertext{r.SelfID(): K},
 		G:             map[party.ID]*paillier.Ciphertext{r.SelfID(): G},
@@ -99,7 +99,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		KShare:        KShare,
 		KNonce:        KNonce,
 		GNonce:        GNonce,
-	}}, nil
+	}, nil
 }
 
 // MessageContent implements round.Round.

--- a/protocols/frost/keygen/round1.go
+++ b/protocols/frost/keygen/round1.go
@@ -96,7 +96,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	}
 
 	// 4. "Every Pᵢ broadcasts Φᵢ, σᵢ to all other participants
-	err = r.SendMessage(out, &message2{Phi_i, Sigma_i, commitment}, "")
+	err = r.BroadcastMessage(out, &broadcast2{Phi_i, Sigma_i, commitment})
 	if err != nil {
 		return r, err
 	}

--- a/protocols/frost/sign/round1.go
+++ b/protocols/frost/sign/round1.go
@@ -86,7 +86,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	E_i := e_i.ActOnBase()
 
 	// Broadcast the commitments
-	err = r.SendMessage(out, &message2{D_i: D_i, E_i: E_i}, "")
+	err = r.BroadcastMessage(out, &broadcast2{D_i: D_i, E_i: E_i})
 	if err != nil {
 		return r, err
 	}

--- a/protocols/frost/sign/round3.go
+++ b/protocols/frost/sign/round3.go
@@ -34,15 +34,15 @@ type round3 struct {
 	Lambda map[party.ID]curve.Scalar
 }
 
-type message3 struct {
+type broadcast3 struct {
 	// Z_i is the response scalar computed by the sender of this message.
 	Z_i curve.Scalar
 }
 
-// VerifyMessage implements round.Round.
-func (r *round3) VerifyMessage(msg round.Message) error {
+// StoreBroadcastMessage implements round.BroadcastRound.
+func (r *round3) StoreBroadcastMessage(msg round.Message) error {
 	from := msg.From
-	body, ok := msg.Content.(*message3)
+	body, ok := msg.Content.(*broadcast3)
 	if !ok || body == nil {
 		return round.ErrInvalidContent
 	}
@@ -72,17 +72,16 @@ func (r *round3) VerifyMessage(msg round.Message) error {
 		return fmt.Errorf("failed to verify response from %v", from)
 	}
 
-	return nil
-}
-
-// StoreMessage implements round.Round.
-func (r *round3) StoreMessage(msg round.Message) error {
-	from, body := msg.From, msg.Content.(*message3)
-
 	r.z[from] = body.Z_i
 
 	return nil
 }
+
+// VerifyMessage implements round.Round.
+func (round3) VerifyMessage(round.Message) error { return nil }
+
+// StoreMessage implements round.Round.
+func (round3) StoreMessage(round.Message) error { return nil }
 
 // Finalize implements round.Round.
 func (r *round3) Finalize(chan<- *round.Message) (round.Session, error) {
@@ -126,8 +125,11 @@ func (r *round3) Finalize(chan<- *round.Message) (round.Session, error) {
 }
 
 // MessageContent implements round.Round.
-func (r *round3) MessageContent() round.Content {
-	return &message3{
+func (round3) MessageContent() round.Content { return nil }
+
+// BroadcastContent implements round.BroadcastRound.
+func (r *round3) BroadcastContent() round.Content {
+	return &broadcast3{
 		Z_i: r.Group().NewScalar(),
 	}
 }


### PR DESCRIPTION
After considering some problems detailed in #36, it became apparent that full identifiable aborts will require all messages to be broadcast. 
This PR changes the `frost` and `cmp` protocols to use broadcast when available

In particular this addresses #60.

The issue of having the `BroadcastRound` interface be inherited by subsequent round is not an issue, since we actually need to broadcast a message in all rounds now. In the future, it may be a good idea to embed `round.BroadcastRound` inside of `round.Round` directly.

We also fix a bug that could have occurred when messages were put in the queue.