### PR TITLE
Implement refresh for FROST

### DIFF
--- a/protocols/doerner/doerner.go
+++ b/protocols/doerner/doerner.go
@@ -48,6 +48,9 @@ func Keygen(group curve.Curve, receiver bool, selfID, otherID party.ID, pl *pool
 //
 // The goal of this protocol is to refresh the shares of the secret key, and other auxilary
 // secret data, while preserving the shared public key.
+//
+// This won't change the value of the public key, but it will change the value of the chaining key.
+// If this isn't desirable, then the new chain key can simply be overwritten with the previous value.
 func RefreshReceiver(config *ConfigReceiver, selfID, otherID party.ID, pl *pool.Pool) protocol.StartFunc {
 	return keygen.StartKeygen(config.Group(), true, selfID, otherID, config.SecretShare, config.Public, pl)
 }

--- a/protocols/frost/keygen/keygen.go
+++ b/protocols/frost/keygen/keygen.go
@@ -24,7 +24,7 @@ var (
 	_ round.Round = (*round3)(nil)
 )
 
-func StartKeygenCommon(taproot bool, group curve.Curve, participants []party.ID, threshold int, selfID party.ID) protocol.StartFunc {
+func StartKeygenCommon(taproot bool, group curve.Curve, participants []party.ID, threshold int, selfID party.ID, privateShare curve.Scalar, publicKey curve.Point, verificationShares map[party.ID]curve.Point) protocol.StartFunc {
 	return func(sessionID []byte) (round.Session, error) {
 		info := round.Info{
 			FinalRoundNumber: protocolRounds,
@@ -44,10 +44,29 @@ func StartKeygenCommon(taproot bool, group curve.Curve, participants []party.ID,
 			return nil, fmt.Errorf("keygen.StartKeygen: %w", err)
 		}
 
+		verificationSharesCopy := make(map[party.ID]curve.Point, len(participants))
+		for k, v := range verificationShares {
+			verificationSharesCopy[k] = v
+		}
+
+		refresh := true
+		if privateShare == nil || publicKey == nil {
+			refresh = false
+			privateShare = group.NewScalar()
+			publicKey = group.NewPoint()
+			for _, k := range participants {
+				verificationSharesCopy[k] = group.NewPoint()
+			}
+		}
+
 		return &round1{
-			Helper:    helper,
-			taproot:   taproot,
-			threshold: threshold,
+			Helper:             helper,
+			taproot:            taproot,
+			threshold:          threshold,
+			refresh:            refresh,
+			privateShare:       privateShare,
+			verificationShares: verificationSharesCopy,
+			publicKey:          publicKey,
 		}, nil
 	}
 }

--- a/protocols/frost/keygen/keygen_test.go
+++ b/protocols/frost/keygen/keygen_test.go
@@ -76,7 +76,7 @@ func TestKeygen(t *testing.T) {
 
 	rounds := make([]round.Session, 0, N)
 	for _, partyID := range partyIDs {
-		r, err := StartKeygenCommon(false, group, partyIDs, N-1, partyID)(nil)
+		r, err := StartKeygenCommon(false, group, partyIDs, N-1, partyID, nil, nil, nil)(nil)
 		require.NoError(t, err, "round creation should not result in an error")
 		rounds = append(rounds, r)
 	}
@@ -148,7 +148,7 @@ func TestKeygenTaproot(t *testing.T) {
 
 	rounds := make([]round.Session, 0, N)
 	for _, partyID := range partyIDs {
-		r, err := StartKeygenCommon(true, group, partyIDs, N-1, partyID)(nil)
+		r, err := StartKeygenCommon(true, group, partyIDs, N-1, partyID, nil, nil, nil)(nil)
 		require.NoError(t, err, "round creation should not result in an error")
 		rounds = append(rounds, r)
 

--- a/protocols/frost/sign/sign_test.go
+++ b/protocols/frost/sign/sign_test.go
@@ -134,7 +134,6 @@ func TestSignTaproot(t *testing.T) {
 			PrivateShare:       privateShares[id],
 			VerificationShares: verificationShares,
 		}
-		result, _ = result.DeriveChild(1)
 		if newPublicKey == nil {
 			newPublicKey = result.PublicKey
 		}


### PR DESCRIPTION
Fixes #64.

This works by creating a secret sharing of 0, as we do in the CMP protocol.