### PR TITLE
fix issues of Pseudo-Key Reveal Fail in Abort2 of presign

### DIFF
--- a/protocols/cmp/presign/abort2.go
+++ b/protocols/cmp/presign/abort2.go
@@ -46,7 +46,7 @@ func (r *abort2) StoreBroadcastMessage(msg round.Message) error {
 	r.KShares[from] = r.Group().NewScalar().SetNat(body.KProof.Plaintext.Mod(r.Group().Order()))
 
 	if !body.YHatProof.Verify(r.HashForID(from), zklog.Public{
-		H: r.ElGamalK[from].L,
+		H: r.ElGamalChi[from].L,
 		X: r.ElGamal[from],
 		Y: body.YHat,
 	}) {
@@ -88,7 +88,7 @@ func (r *abort2) Finalize(chan<- *round.Message) (round.Session, error) {
 
 		}
 
-		if !M.Equal(r.ElGamalK[j].M) {
+		if !M.Equal(r.ElGamalChi[j].M) {
 			culprits = append(culprits, j)
 		}
 	}

--- a/protocols/cmp/presign/presign7.go
+++ b/protocols/cmp/presign/presign7.go
@@ -100,14 +100,14 @@ func (r *presign7) Finalize(out chan<- *round.Message) (round.Session, error) {
 
 	// ∑ⱼ Sⱼ ?= X
 	if !r.PublicKey.Equal(PublicKeyComputed) {
-		YHat := r.ElGamalKNonce.Act(r.ElGamal[r.SelfID()])
+		YHat := r.ElGamalChiNonce.Act(r.ElGamal[r.SelfID()])
 		YHatProof := zklog.NewProof(r.Group(), r.HashForID(r.SelfID()), zklog.Public{
-			H: r.ElGamalKNonce.ActOnBase(),
+			H: r.ElGamalChiNonce.ActOnBase(),
 			X: r.ElGamal[r.SelfID()],
 			Y: YHat,
 		}, zklog.Private{
-			A: r.ElGamalKNonce,
-			B: r.SecretElGamal,
+			A: r.SecretElGamal,
+			B: r.ElGamalChiNonce,
 		})
 
 		ChiProofs := make(map[party.ID]*abortNth, r.N()-1)


### PR DESCRIPTION
It seems that the algorithm implemented in `presign.Abort2` dosen't match the one described in the [original paper](https://eprint.iacr.org/2021/060.pdf)

![image](https://user-images.githubusercontent.com/8242525/198249362-d6f774b6-ddad-4ff9-b437-eba9bd9043b6.png)

As shown above, we should use `ElGamalChi` instead of `ElGamalK`. 

Also in the implemention code below, we have calculated `Ŷⱼ + kⱼ⋅Xⱼ+ ∑ₗ (α̂ⱼₗ⋅G + kₗ⋅Xⱼ- α̂ₗⱼ⋅G)`, 

which is `Ŷⱼ+ ( kⱼ⋅xⱼ⋅G+ ∑ₗ (α̂ⱼₗ + kₗ⋅xⱼ- α̂ₗⱼ)⋅G) = Ŷⱼ+ χᵢ⋅G`. 

That's the ElGamal commitment of ` χᵢ` (known as `ElGamalChi`) in code.

![image](https://user-images.githubusercontent.com/8242525/198254358-e67f101d-1548-45d8-87c1-f5689d7c1b47.png)

