### PR TITLE
Fix protocol ID for Frost

### DIFF
--- a/protocols/frost/keygen/keygen.go
+++ b/protocols/frost/keygen/keygen.go
@@ -34,9 +34,9 @@ func StartKeygenCommon(taproot bool, group curve.Curve, participants []party.ID,
 			Group:            group,
 		}
 		if taproot {
-			info.ProtocolID = protocolID
-		} else {
 			info.ProtocolID = protocolIDTaproot
+		} else {
+			info.ProtocolID = protocolID
 		}
 
 		helper, err := round.NewSession(info, sessionID, nil)


### PR DESCRIPTION
The Taproot variant of Frost gets its own protocol ID, but the protocol IDs were assigned in reverse. This puts them in the right order.