### PR TITLE
Fix config cloning

### DIFF
--- a/protocols/frost/keygen/config.go
+++ b/protocols/frost/keygen/config.go
@@ -141,7 +141,7 @@ func (r *TaprootConfig) Clone() *TaprootConfig {
 		PrivateShare:       curve.Secp256k1{}.NewScalar().Set(r.PrivateShare).(*curve.Secp256k1Scalar),
 		PublicKey:          publicKeyCopy,
 		ChainKey:           chainKeyCopy,
-		VerificationShares: r.VerificationShares,
+		VerificationShares: verificationSharesCopy,
 	}
 }
 


### PR DESCRIPTION
When cloning a `TaprootConfig`, a copy of the verification shares is created but not used. This uses the copy of the verification shares.