### PR TITLE
Convert z to Z to be able to marshal and unmarshal the frost Signature.

### DIFF
--- a/protocols/frost/sign/round3.go
+++ b/protocols/frost/sign/round3.go
@@ -10,7 +10,8 @@ import (
 )
 
 // This corresponds with step 7 of Figure 3 in the Frost paper:
-//   https://eprint.iacr.org/2020/852.pdf
+//
+//	https://eprint.iacr.org/2020/852.pdf
 //
 // The big difference, once again, stems from their being no signing authority.
 // Instead, each participant calculates the signature on their own.
@@ -114,7 +115,7 @@ func (r *round3) Finalize(chan<- *round.Message) (round.Session, error) {
 	} else {
 		sig := Signature{
 			R: r.R,
-			z: z,
+			Z: z,
 		}
 
 		if !sig.Verify(r.Y, r.M) {

--- a/protocols/frost/sign/types.go
+++ b/protocols/frost/sign/types.go
@@ -29,14 +29,14 @@ func (messageHash) Domain() string {
 //
 // This signature claims to satisfy:
 //
-//    z * G = R + H(R, Y, m) * Y
+//	z * G = R + H(R, Y, m) * Y
 //
 // for a public key Y.
 type Signature struct {
 	// R is the commitment point.
 	R curve.Point
 	// z is the response scalar.
-	z curve.Scalar
+	Z curve.Scalar
 }
 
 // Verify checks if a signature equation actually holds.
@@ -52,7 +52,7 @@ func (sig Signature) Verify(public curve.Point, m []byte) bool {
 	expected := challenge.Act(public)
 	expected = expected.Add(sig.R)
 
-	actual := sig.z.ActOnBase()
+	actual := sig.Z.ActOnBase()
 
 	return expected.Equal(actual)
 }


### PR DESCRIPTION
frost Signature do not have marshal and unmarshal functions while ecdsa Signature have. So, marked z scalar to be public field of Signature for the custom marshal and unmarshalling. 