### PR TITLE
Fix nil casting in proof.Verify

### DIFF
--- a/pkg/zk/affg/affg.go
+++ b/pkg/zk/affg/affg.go
@@ -173,7 +173,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}

--- a/pkg/zk/affp/affp.go
+++ b/pkg/zk/affp/affp.go
@@ -179,7 +179,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(group curve.Curve, hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(group curve.Curve, hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}

--- a/pkg/zk/elog/elog.go
+++ b/pkg/zk/elog/elog.go
@@ -85,7 +85,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}

--- a/pkg/zk/enc/enc.go
+++ b/pkg/zk/enc/enc.go
@@ -98,7 +98,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(group curve.Curve, hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(group curve.Curve, hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}

--- a/pkg/zk/encelg/encelg.go
+++ b/pkg/zk/encelg/encelg.go
@@ -124,7 +124,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}

--- a/pkg/zk/log/log.go
+++ b/pkg/zk/log/log.go
@@ -77,7 +77,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	if !p.IsValid() {
 		return false
 	}

--- a/pkg/zk/logstar/logstar.go
+++ b/pkg/zk/logstar/logstar.go
@@ -116,7 +116,7 @@ func NewProof(group curve.Curve, hash *hash.Hash, public Public, private Private
 	}
 }
 
-func (p Proof) Verify(hash *hash.Hash, public Public) bool {
+func (p *Proof) Verify(hash *hash.Hash, public Public) bool {
 	if !p.IsValid(public) {
 		return false
 	}


### PR DESCRIPTION
fixes #99 

proof.Verify should handle the case of a nil proof, and thus must be a pointer receiver, otherwise sending an empty proof will cause the verifier to panic.