### PR TITLE
Fix challenge generation for zkmod

### DIFF
--- a/pkg/zk/mod/mod.go
+++ b/pkg/zk/mod/mod.go
@@ -262,8 +262,9 @@ func (p *Proof) Verify(public Public, hash *hash.Hash, pl *pool.Pool) bool {
 func challenge(hash *hash.Hash, n *saferith.Modulus, w *big.Int) (es []*saferith.Nat, err error) {
 	err = hash.WriteAny(n, w)
 	es = make([]*saferith.Nat, params.StatParam)
+	var digest = hash.Digest()
 	for i := range es {
-		es[i] = sample.ModN(hash.Digest(), n)
+		es[i] = sample.ModN(digest, n)
 	}
 	return
 }

--- a/pkg/zk/mod/mod_test.go
+++ b/pkg/zk/mod/mod_test.go
@@ -88,7 +88,6 @@ func Test_hashFix(t *testing.T) {
 
 	allEqual := true
 	for _, e := range es {
-		println(e.String())
 		if !(e.Eq(es[0]) == 1) {
 			allEqual = false
 		}

--- a/pkg/zk/mod/mod_test.go
+++ b/pkg/zk/mod/mod_test.go
@@ -79,6 +79,24 @@ func Test_set4thRoot(t *testing.T) {
 	assert.True(t, root.Eq(y) == 1, "root^4 should be equal to y")
 }
 
+func Test_hashFix(t *testing.T) {
+	N := zk.ProverPaillierSecret.N()
+	w := sample.QNR(rand.Reader, N).Big()
+	h := hash.New()
+	es, err := challenge(h, N, w)
+	assert.NoError(t, err, "failed to compute challenge")
+
+	allEqual := true
+	for _, e := range es {
+		println(e.String())
+		if !(e.Eq(es[0]) == 1) {
+			allEqual = false
+		}
+	}
+
+	assert.False(t, allEqual, "all challenges should be different")
+}
+
 var proof *Proof
 
 func BenchmarkCRT(b *testing.B) {


### PR DESCRIPTION
The `mod` ZK proof for ensuring that each party's Paillier modulus is correct contained a bug in the challenge generation phase. For statistical soundness, the test is repeated 80 times, with different challenges `e`. These values were sampled by recreating the **same** random stream from the hash function at every iteration, resulting in all challenges being equal. This effectively reduced the soundness probability to 1/2 instead of 1/2^80.

An attacker would be able to trivially produce a valid proof for an invalid modulus during keygen/refresh. 

After applying this fix, we recommend refreshing all existing keys to ensure all parties use correct Paillier moduli. 