### PR TITLE
Make doerner18 configs serializable

### DIFF
--- a/internal/ot/correlated_test.go
+++ b/internal/ot/correlated_test.go
@@ -38,6 +38,44 @@ func runCorreOTSetup(pl *pool.Pool, hash *hash.Hash) (*CorreOTSendSetup, *CorreO
 	return sendSetup, receiveSetup, nil
 }
 
+func TestMarshalingOTSetup(t *testing.T) {
+	pl := pool.NewPool(0)
+	defer pl.TearDown()
+	sendSetup, receiveSetup, err := runCorreOTSetup(pl, hash.New())
+	sendSetupBytes, err := sendSetup.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+	receiveSetupBytes, err := receiveSetup.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	newSendSetup := &CorreOTSendSetup{}
+	newSendSetup.UnmarshalJSON(sendSetupBytes)
+
+	newReceiveSetup := &CorreOTReceiveSetup{}
+	newReceiveSetup.UnmarshalJSON(receiveSetupBytes)
+
+	for i := 0; i < params.OTParam; i++ {
+		if !bytes.Equal(newReceiveSetup._K_0[i][:], receiveSetup._K_0[i][:]) {
+			t.Error("receiveSetup._K_0 diff")
+		}
+		if !bytes.Equal(newReceiveSetup._K_1[i][:], receiveSetup._K_1[i][:]) {
+			t.Error("receiveSetup._K_1 diff")
+		}
+	}
+
+	if !bytes.Equal(newSendSetup._Delta[:], sendSetup._Delta[:]) {
+		t.Error("sender._Delta diff")
+	}
+	for i := 0; i < params.OTParam; i++ {
+		if !bytes.Equal(newSendSetup._K_Delta[i][:], sendSetup._K_Delta[i][:]) {
+			t.Error("send._K_Delta[i]")
+		}
+	}
+}
+
 func TestCorreOTSetup(t *testing.T) {
 	pl := pool.NewPool(0)
 	defer pl.TearDown()

--- a/protocols/doerner/keygen/keygen.go
+++ b/protocols/doerner/keygen/keygen.go
@@ -2,6 +2,7 @@ package keygen
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -26,6 +27,13 @@ type ConfigReceiver struct {
 	Public curve.Point
 	// ChainKey is the shared chain key.
 	ChainKey []byte
+}
+
+type ConfigMarshal struct {
+	Setup       []byte
+	SecretShare []byte
+	Public      []byte
+	ChainKey    []byte
 }
 
 // Group returns the elliptic curve group associate with this config.
@@ -71,6 +79,35 @@ func (c *ConfigReceiver) DeriveBIP32(i uint32) (*ConfigReceiver, error) {
 		return nil, err
 	}
 	return c.Derive(scalar, newChainKey)
+}
+
+func (c *ConfigReceiver) MarshalJSON() ([]byte, error) {
+	secretShare, err := c.SecretShare.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configReceiver.SecretShare: %v", err)
+	}
+	public, err := c.Public.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configReceiver.Public: %v", err)
+	}
+	setup, err := c.Setup.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configReceiver.Setup: %v", err)
+	}
+
+	output := ConfigMarshal{
+		Setup:       setup,
+		SecretShare: secretShare,
+		Public:      public,
+		ChainKey:    c.ChainKey,
+	}
+
+	res, err := json.Marshal(output)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal keygen output: %v", err)
+	}
+
+	return res, nil
 }
 
 // ConfigSender holds the results of key generation for the sender.
@@ -182,4 +219,33 @@ func (c *ConfigSender) DeriveBIP32(i uint32) (*ConfigSender, error) {
 		return nil, err
 	}
 	return c.Derive(scalar, newChainKey)
+}
+
+func (c *ConfigSender) MarshalJSON() ([]byte, error) {
+	secretShare, err := c.SecretShare.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configSender.SecretShare: %v", err)
+	}
+	public, err := c.Public.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configSender.Public: %v", err)
+	}
+	setup, err := c.Setup.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal configSender.Setup: %v", err)
+	}
+
+	output := ConfigMarshal{
+		Setup:       setup,
+		SecretShare: secretShare,
+		Public:      public,
+		ChainKey:    c.ChainKey,
+	}
+
+	res, err := json.Marshal(output)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal keygen output: %v", err)
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
In my company, we needed to persist the result of the doerner18 dkg so that we can sign later on.

To do so, we needed to be able to serialize the Setup generated during the dkg.

This pull requests makes this possible.

I assume that this pull request is far from being ready for merge, but I'm starting the conversation and hoping that you will point me to the changes to be made to eventually be able to merge this upstream.
