### PR TITLE
Fix "Typos and best practices"

### DIFF
--- a/internal/round/error.go
+++ b/internal/round/error.go
@@ -5,5 +5,5 @@ import "errors"
 var (
 	ErrNilFields      = errors.New("message contained empty fields")
 	ErrInvalidContent = errors.New("content is not the right type")
-	ErrOutChanFull    = errors.New("content is not the right type")
+	ErrOutChanFull    = errors.New("out channel is full")
 )

--- a/internal/round/number.go
+++ b/internal/round/number.go
@@ -12,7 +12,7 @@ type Number uint16
 // WriteTo implements io.WriterTo interface.
 func (i Number) WriteTo(w io.Writer) (int64, error) {
 	err := binary.Write(w, binary.BigEndian, uint64(i))
-	return 2, err
+	return 8, err
 }
 
 // Domain implements hash.WriterToWithDomain.

--- a/pkg/math/curve/curve.go
+++ b/pkg/math/curve/curve.go
@@ -62,7 +62,7 @@ type Scalar interface {
 	Sub(Scalar) Scalar
 	// Negate mutates this Scalar, replacing it with its negation.
 	Negate() Scalar
-	// Mul mutates this Scalar, replacing it with another.
+	// Mul mutates this Scalar, by multiplying it with another.
 	Mul(Scalar) Scalar
 	// Invert mutates this Scalar, replacing it with its multiplicative inverse.
 	Invert() Scalar

--- a/pkg/math/curve/secp256k1.go
+++ b/pkg/math/curve/secp256k1.go
@@ -51,6 +51,8 @@ func (Secp256k1) Order() *saferith.Modulus {
 	return secp256k1Order
 }
 
+// LiftX creates a Secp256k1Point from the given byte slice.
+// The input data is truncated to the first 32 bytes and any additional bytes are ignored.
 func (Secp256k1) LiftX(data []byte) (*Secp256k1Point, error) {
 	out := new(Secp256k1Point)
 	out.value.Z.SetInt(1)

--- a/pkg/math/polynomial/exponent.go
+++ b/pkg/math/polynomial/exponent.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 
-	"github.com/cronokirby/saferith"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/taurusgroup/multi-party-sig/pkg/math/curve"
 )
@@ -59,30 +58,6 @@ func (p *Exponent) Evaluate(x curve.Scalar) curve.Point {
 		result = x.Act(result)
 	}
 
-	return result
-}
-
-// evaluateClassic evaluates a polynomial in a given variable index
-// We do the classic method, where we compute all powers of x.
-func (p *Exponent) evaluateClassic(x curve.Scalar) curve.Point {
-	var tmp curve.Point
-
-	xPower := p.group.NewScalar().SetNat(new(saferith.Nat).SetUint64(1))
-	result := p.group.NewPoint()
-
-	if p.IsConstant {
-		// since we start at index 1 of the polynomial, x must be x and not 1
-		xPower.Mul(x)
-	}
-
-	for i := 0; i < len(p.coefficients); i++ {
-		// tmp = [xⁱ]Aᵢ
-		tmp = xPower.Act(p.coefficients[i])
-		// result += [xⁱ]Aᵢ
-		result = result.Add(tmp)
-		// x = xⁱ⁺¹
-		xPower.Mul(x)
-	}
 	return result
 }
 
@@ -180,7 +155,6 @@ func (*Exponent) Domain() string {
 }
 
 func EmptyExponent(group curve.Curve) *Exponent {
-	// TODO create custom marshaller
 	return &Exponent{group: group}
 }
 

--- a/pkg/party/idslice.go
+++ b/pkg/party/idslice.go
@@ -17,6 +17,7 @@ func NewIDSlice(partyIDs []ID) IDSlice {
 }
 
 // Contains returns true if partyIDs contains id.
+// Returns true only if all ids are present.
 // Assumes that the IDSlice is valid.
 func (partyIDs IDSlice) Contains(ids ...ID) bool {
 	for _, id := range ids {
@@ -65,6 +66,7 @@ func (partyIDs IDSlice) Swap(i, j int)      { partyIDs[i], partyIDs[j] = partyID
 func (partyIDs IDSlice) sort() { sort.Sort(partyIDs) }
 
 // search returns the result of applying SearchStrings to the receiver and x.
+// Assumes the id slice is valid.
 func (partyIDs IDSlice) search(x ID) (int, bool) {
 	index := sort.Search(len(partyIDs), func(i int) bool { return partyIDs[i] >= x })
 	if index >= 0 && index < len(partyIDs) && partyIDs[index] == x {
@@ -74,7 +76,7 @@ func (partyIDs IDSlice) search(x ID) (int, bool) {
 }
 
 // WriteTo implements io.WriterTo and should be used within the hash.Hash function.
-// It writes the full uncompressed point to w, ie 64 bytes.
+// It writes the party ID string to w, ie 64 bytes.
 func (partyIDs IDSlice) WriteTo(w io.Writer) (int64, error) {
 	if partyIDs == nil {
 		return 0, io.ErrUnexpectedEOF

--- a/pkg/protocol/handler.go
+++ b/pkg/protocol/handler.go
@@ -87,7 +87,7 @@ func (h *MultiHandler) Listen() <-chan *Message {
 	return h.out
 }
 
-// CanAccept returns true if the message is designated for this protocol protocol execution.
+// CanAccept returns true if the message is designated for this protocol execution.
 func (h *MultiHandler) CanAccept(msg *Message) bool {
 	r := h.currentRound
 	if msg == nil {
@@ -136,7 +136,7 @@ func (h *MultiHandler) Accept(msg *Message) {
 	defer h.mtx.Unlock()
 
 	// exit early if the message is bad, or if we are already done
-	if !h.CanAccept(msg) || h.err != nil || h.result != nil || h.duplicate(msg) {
+	if !h.CanAccept(msg) || h.err != nil || h.result != nil || h.isDuplicate(msg) {
 		return
 	}
 
@@ -347,6 +347,9 @@ func (h *MultiHandler) abort(err error, culprits ...party.ID) {
 
 // Stop cancels the current execution of the protocol, and alerts the other users.
 func (h *MultiHandler) Stop() {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+
 	if h.err != nil || h.result != nil {
 		h.abort(errors.New("aborted by user"), h.currentRound.SelfID())
 	}
@@ -399,7 +402,7 @@ func (h *MultiHandler) receivedAll() bool {
 	return true
 }
 
-func (h *MultiHandler) duplicate(msg *Message) bool {
+func (h *MultiHandler) isDuplicate(msg *Message) bool {
 	if msg.RoundNumber == 0 {
 		return false
 	}

--- a/pkg/protocol/twoparty.go
+++ b/pkg/protocol/twoparty.go
@@ -44,11 +44,11 @@ func NewTwoPartyHandler(create StartFunc, sessionID []byte, leader bool) (*TwoPa
 func (h *TwoPartyHandler) Result() (interface{}, error) {
 	h.mtx.Lock()
 	defer h.mtx.Unlock()
-	if h.result != nil {
-		return h.result, nil
-	}
 	if h.err != nil {
 		return nil, h.err
+	}
+	if h.result != nil {
+		return h.result, nil
 	}
 	return nil, errors.New("protocol: not finished")
 }

--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -107,6 +107,7 @@ func (z *Response) Verify(hash *hash.Hash, public curve.Point, commitment *Commi
 }
 
 // Verify checks that Proof.Response•G = Proof.Commitment + H(..., Proof.Commitment, Public)•Public.
+// Proof commitment point must lie on the curve.
 func (p *Proof) Verify(hash *hash.Hash, public, gen curve.Point) bool {
 	if !p.IsValid() {
 		return false

--- a/protocols/frost/keygen/config.go
+++ b/protocols/frost/keygen/config.go
@@ -151,11 +151,11 @@ func (r *TaprootConfig) Clone() *TaprootConfig {
 //
 // Optionally, a new chain key can be passed as well.
 func (r *TaprootConfig) Derive(adjust *curve.Secp256k1Scalar, newChainKey []byte) (*TaprootConfig, error) {
+	if len(newChainKey) > 0 && len(newChainKey) != params.SecBytes {
+		return nil, fmt.Errorf("expecte %d bytes for chain key, found %d", params.SecBytes, len(newChainKey))
+	}
 	if len(newChainKey) <= 0 {
 		newChainKey = r.ChainKey
-	}
-	if len(newChainKey) != params.SecBytes {
-		return nil, fmt.Errorf("expecte %d bytes for chain key, found %d", params.SecBytes, len(newChainKey))
 	}
 
 	adjustG := adjust.ActOnBase()

--- a/protocols/frost/keygen/round1.go
+++ b/protocols/frost/keygen/round1.go
@@ -15,7 +15,8 @@ import (
 )
 
 // This round corresponds with the steps 1-4 of Round 1, Figure 1 in the Frost paper:
-//   https://eprint.iacr.org/2020/852.pdf
+//
+//	https://eprint.iacr.org/2020/852.pdf
 type round1 struct {
 	*round.Helper
 	// taproot indicates whether or not to make taproot compatible keys.
@@ -120,7 +121,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		return r, fmt.Errorf("failed to commit to chain key")
 	}
 
-	// 4. "Every Pᵢ broadcasts Φᵢ, σᵢ to all other participants
+	// 4. "Every Pᵢ broadcasts Φᵢ, σᵢ, Cᵢ to all other participants
 	err = r.BroadcastMessage(out, &broadcast2{
 		Phi_i:      Phi_i,
 		Sigma_i:    Sigma_i,

--- a/protocols/frost/keygen/round3.go
+++ b/protocols/frost/keygen/round3.go
@@ -47,8 +47,7 @@ func (r *round3) StoreBroadcastMessage(msg round.Message) error {
 		return err
 	}
 
-	// Verify that the commitment to the chain key contribution matches, and then xor
-	// it into the accumulated chain key so far.
+	// Verify that the commitment to the chain key contribution matches
 	if !r.HashForID(from).Decommit(r.ChainKeyCommitments[from], body.Decommitment, body.C_l) {
 		return fmt.Errorf("failed to verify chain key commitment")
 	}

--- a/protocols/frost/sign/types.go
+++ b/protocols/frost/sign/types.go
@@ -29,7 +29,7 @@ func (messageHash) Domain() string {
 //
 // This signature claims to satisfy:
 //
-//    z * G = R + H(R, Y, m) * Y
+//	z * G = R + H(R, Y, m) * Y
 //
 // for a public key Y.
 type Signature struct {
@@ -40,13 +40,14 @@ type Signature struct {
 }
 
 // Verify checks if a signature equation actually holds.
+// The public point must be a valid point on the curve.
 //
 // Note that m is the hash of a message, and not the message itself.
-func (sig Signature) Verify(public curve.Point, m []byte) bool {
+func (sig Signature) Verify(public curve.Point, m messageHash) bool {
 	group := public.Curve()
 
 	challengeHash := hash.New()
-	_ = challengeHash.WriteAny(sig.R, public, messageHash(m))
+	_ = challengeHash.WriteAny(sig.R, public, m)
 	challenge := sample.Scalar(challengeHash.Digest(), group)
 
 	expected := challenge.Act(public)


### PR DESCRIPTION
Changes not implemented:
 - ThresholdWrapper - used only once as threshold wrapper and would require each time threshold is used to convert the types so it was not worth it
 - Derive - used in external libraries to derive a key per signing based on sighash
 - CanAccept used in external libraries
 -  hash.WriteMany - too many changes 
 - magic numbers not sure what this specifically refers to